### PR TITLE
7 edges incorrectly classified as vessels

### DIFF
--- a/vasculature/SCC_main.sh
+++ b/vasculature/SCC_main.sh
@@ -11,7 +11,7 @@
 # Specify number of cores
 #$ -pe omp 16
 # Specify memory per core
-#$ -l mem_per_core=13G
+#$ -l mem_per_core=16G
 
 # Send email upon completion
 #$ -m ea

--- a/vasculature/SCC_main.sh
+++ b/vasculature/SCC_main.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -l
+
+#$ -P npbssmic
+#$ -pe omp 28
+#$ -l mem_per_core=13G
+#$ -m ea
+#$ -l h_rt=24:00:00
+#$ -N vessel_segmentation
+#$ -j y
+
+module load matlab/2020b
+matlab -nodisplay -singleCompThread -r "psoct_vessel_segmentation_main; exit"
+

--- a/vasculature/SCC_main.sh
+++ b/vasculature/SCC_main.sh
@@ -1,11 +1,28 @@
 #!/bin/bash -l
 
+# Set SCC project
 #$ -P npbssmic
-#$ -pe omp 28
+
+# Specify job to run on lab's buy-in computers on SCC
+#$ -l buyin
+
+
+# Request a whole node with 28 cores and at least 384 GB of RAM.
+# Specify number of cores
+#$ -pe omp 16
+# Specify memory per core
 #$ -l mem_per_core=13G
+
+# Send email upon completion
 #$ -m ea
+
+# Time limit for job
 #$ -l h_rt=24:00:00
-#$ -N vessel_segmentation
+
+# Name of job
+#$ -N ves_seg_graph
+
+# Combine output/error files into single file
 #$ -j y
 
 module load matlab/2020b

--- a/vasculature/psoct_vessel_segmentation_main.m
+++ b/vasculature/psoct_vessel_segmentation_main.m
@@ -104,32 +104,33 @@ segmat2tif(I_seg, fout);
 %%% Create 3D mask
 mask = logical(vol);
 
-%%% Erode mask to remove small pixels on border that are not part of volume
-se = strel('disk',10);
-mask = imerode(mask, se);
+radii = [10:2:22];
 
-%%% Remove islands of pixels from mask
-% Range of object size to keep
-range = [1e4, 1e8];
-mask = remove_mask_islands(mask, range);
-
-%%% Apply mask to segmentation volume
-% Convert from logical back to uint16 for matrix multiplication
-mask = uint16(mask);
-% Element-wise multiply mask and volume
-I_seg_masked = apply_mask(I_seg, mask);
-%}
-
-%% Save segmented/masked volume as .MAT and .TIF
-
-% Convert masked image back to tif
-fname = strcat(fname,'_masked');
-fout = strcat(dpath, fname, '.tif');
-segmat2tif(I_seg_masked, fout);
-
-% Save vessel segment stack as .MAT for the next step (graph recon)
-fout = strcat(dpath, fname, '.mat');
-save(fout, 'I_seg_masked', '-v7.3');
+for ii = 1:10
+    %%% Erode mask to remove small pixels on border that are not part of volume
+    se = strel('disk', radii(ii));
+    mask = imerode(mask, se);
+    
+    %%% Remove islands of pixels from mask
+    % Range of object size to keep
+    range = [1e4, 1e8];
+    mask = remove_mask_islands(mask, range);
+    
+    %%% Apply mask to segmentation volume
+    % Convert from logical back to uint16 for matrix multiplication
+    mask = uint16(mask);
+    % Element-wise multiply mask and volume
+    I_seg_masked = apply_mask(I_seg, mask);
+    
+    %%% Save segmented/masked volume as .MAT and .TIF
+    % Convert masked image back to tif
+    fname = strcat(fname,'_masked_radius_', num2str(radii(ii)));
+    fout = strcat(dpath, fname, '.tif');
+    segmat2tif(I_seg_masked, fout);
+    % Save vessel segment stack as .MAT for the next step (graph recon)
+    fout = strcat(dpath, fname, '.mat');
+    save(fout, 'I_seg_masked', '-v7.3');
+end
 
 %% Convert segmentation to graph
 

--- a/vasculature/psoct_vessel_segmentation_main.m
+++ b/vasculature/psoct_vessel_segmentation_main.m
@@ -69,8 +69,14 @@ end
 % Downasample factor = 10 --> Voxel = [30, 30, 35] micron
 % 2P microscopy voxel will always be 5um x 5um
 
-% PS-OCT voxel dimensions (microns) (hard coded for debugging)
-vox_dim = [30, 30, 35];
+% Set voxel dimensions from filename
+if regexp(fname, '4ds')
+    vox_dim = [12, 12, 15];
+elseif regexp(fname, '10ds')
+    vox_dim = [30, 30, 35];
+else
+    vox_dim = [30, 30, 35];
+end
 
 % Std. Dev. for gaussian filter (one value or array)
 % The value of sigma corresponds to the smallest resolvable radius of the
@@ -87,7 +93,7 @@ min_conn = 30;
 radii = 40;
 
 % Boolean for converting segment to graph (0 = don't convert, 1 = convert)
-graph_boolean = 0;
+graph_boolean = 1;
 
 for ii = 1:length(subid)
     %% Segment the volume
@@ -119,8 +125,8 @@ for ii = 1:length(subid)
                 % Use masked segmentation to create graph
                 Graph = seg_to_graph(I_seg_masked, vox_dim);
                 
-                % initialize graph information
-        %         Graph = initialize_graph(Graph);
+                % Initialize graph information (work in progress)
+                % Graph = initialize_graph(Graph);
         
                 % Create new filename for graph and add .MAT extension
                 fname_graph = strcat(fname_seg,'_mask', num2str(radii(k)),'_graph.mat');

--- a/vasculature/psoct_vessel_segmentation_main.m
+++ b/vasculature/psoct_vessel_segmentation_main.m
@@ -32,32 +32,6 @@ end
 topdir = mydir(1:idcs(end));
 addpath(genpath(topdir));
 
-%% Automate segmentation of multiple volumes
-%{
-dpath = '/projectnb/npbssmic/ns/Ann_Mckee_samples_10T/';
-subid = {'AD_10382', 'AD_20832', 'AD_20969', 'AD_21354', 'AD_21424',...
-         'CTE_6489', 'CTE_6912', 'CTE_7019', 'CTE_8572', 'CTE_7126',...
-         'NC_21499', 'NC_6047', 'NC_6839', 'NC_6974', 'NC_7597',...
-         'NC_8095', 'NC_8653'};
-for ii = length(subid)
-    % Set voxel size from filename (either "_10ds" or "_4ds")
-
-    % Segment
-
-    % Mask
-
-    % Convert to graph
-
-    % Initialize graph structure information
-
-    % Downsample graph
-
-    % Prune loops
-
-    % Straighten segments
-end
-%}
-
 %% Import volume (.TIF or .BTF) & convert to MAT 
 
 % Check if running on local machine for debugging or on SCC for processing
@@ -80,7 +54,7 @@ elseif isunix
 %              'CTE_6489', 'CTE_6912', 'CTE_7019', 'CTE_8572', 'CTE_7126',...
 %              'NC_21499', 'NC_6047', 'NC_6839', 'NC_6974', 'NC_7597',...
 %              'NC_8095', 'NC_8653'};
-    subid = {'AD_10382', 'AD_20832'};
+    subid = {'AD_20969', 'AD_21354'};
     subdir = '/dist_corrected/volume/';
     % Filename to parse (this will be the same for each subject)
     fname = 'ref_4ds_norm';
@@ -105,7 +79,7 @@ thresh = 0.2;
 min_conn = 30;
 
 % Array of radii for eroding the mask
-radii = 10:2:14;
+radii = 16:4:50;
 
 % Boolean for converting segment to graph (0 = don't convert, 1 = convert)
 graph_boolean = 1;
@@ -145,7 +119,7 @@ for ii = 1:length(subid)
     
             % Create new filename for graph and add .MAT extension
             fname_graph = strcat(fname_seg,'_masked_radius_', num2str(radii(j)),'_graph.mat');
-            fout = strcat(dpath, fname_graph);
+            fout = strcat(fullpath, fname_graph);
             save(fout,'Graph');
         end
     end

--- a/vasculature/psoct_vessel_segmentation_main.m
+++ b/vasculature/psoct_vessel_segmentation_main.m
@@ -104,7 +104,7 @@ segmat2tif(I_seg, fout);
 %%% Create 3D mask
 mask = logical(vol);
 
-radii = [10:2:22];
+radii = 10:2:22;
 
 for ii = 1:10
     %%% Erode mask to remove small pixels on border that are not part of volume
@@ -149,89 +149,6 @@ save(fout,'Graph');
 % Open GUI with both image and data (graph)
 % Run prune_loops and prune_segment
 % Run straighten
-
-
-%% Perform manual pruning
-% The user must use the matlab GUI to manually remove these segments
-
-%% Calculate Diameter
-%{
-% Load Graph struct
-fname = 'volume_nor_inverted_masked_sigma1_frangi_seg_regraphed';
-dpath =...
-    'C:\Users\mack\Documents\BU\Boas_Lab\psoct_human_brain_resources\test_data\Hui_Frangi_dataset\200726PSOCT\';
-fpath = strcat(dpath, strcat(fname,'.mat'));
-Data = load(fpath,'Graph');
-
-% Call function to calculate diameter at each node
-Diam = GetDiam_graph(...
-    vol,...
-    Data.Graph.nodes,...
-    Data.Graph.edges,...
-    Ithresh,...
-    vox_dim);
-%}
-%% Calculate Tortuosity
-%{
-tortuosity = vessel_tortuosity_index(Data.Graph, Ithresh);
-%}
-%% Histograms for geometries
-%{
-% Histo for diameter
-figure; histogram(Diam);
-title('Vessel Diameter')
-xlabel('Diameter (microns)')
-ylabel('Count')
-set(gca, 'FontSize', 20)
-
-% Histo for diameter
-figure; histogram(tortuosity);
-title('Vessel Tortuosity')
-xlabel('Tortuosity (unitless)')
-ylabel('Count'); ylim([0,200])
-set(gca, 'FontSize', 20)
-%}
-
-%% (OLD CODE) Median diameter
-%{
-dia_vessel=zeros(1,length(Data.Graph.segInfo.segLen));
-for i=1:length(dia_vessel)
-    dia_vessel(i)=median(Diam(find(Data.Graph.segInfo.nodeSegN(:)==i)));
-end
-figure; histogram(dia_vessel,'BinWidth',10);
-%}
-
-%% (OLD CODE) length of each vessel
-%{
-% remove fake vessels
-length_vessel( length_vessel(:)==0 ) = [];
-figure;
-histogram(length_vessel.*10,0:25:1000);
-%}
-
-
-%% (OLD CODE) extract vessels and clean up boundaries by creating a mask
-%{
-V_seg=TIFF2MAT('I_seg_Ann.tif');
-mask=TIFF2MAT('I_mask.tif');
-for i=1:size(img,3)
-    mask_tmp=squeeze(mask(:,:,i));
-    mask_tmp(mask_tmp(:)~=0)=1;
-    mask_tmp = bwareaopen(logical(mask_tmp), 500);
-    V_seg(:,:,i)=uint16(mask_tmp).*squeeze(V_seg(:,:,i));
-    % figure;imshow(mask_tmp);
-end
-MAT2TIFF(V_seg,'I_seg_masked2.tif');
-%}
-
-%% (OLD CODE) calculate topology
-%{
-% skeletonization
-I_seg=TIFF2MAT('I_seg_nor_mask.tif');
-I_seg(I_seg(:)~=0)=1;
-I_skel=bwskel(logical(I_seg));
-MAT2TIFF(I_skel,'I_seg_skel.tif');
-%}
 
 %% Apply Mask
 function [I_seg_masked] = mask_segments(I, I_seg, epsilon)

--- a/vasculature/psoct_vessel_segmentation_main.m
+++ b/vasculature/psoct_vessel_segmentation_main.m
@@ -5,22 +5,22 @@
 % Detailed Description
 %{
 This script performs the following:
-- segmentation ()
-- convert segmentation to graph ()
+- segment the original volume
+- apply a mask to the segmentation
+- convert segmentation to graph
 - prune graph (remove loops and unterminated segments)
     - remove loops ()
     - remove segments ()
-- overlay graph and image
-- diameter
-- tortuosity (vessel_tortuosity_index.m)
-- length
-- topology (why does this use the mask?)
+
+To Do:
+- find optimal range for remove_mask_islands
 %}
 clear; clc; close all;
 
 %% Add top-level directory of code repository to path
 % This allows Matlab to find the functions in the project folders
-% Print current working directory
+
+% Start in current directory
 mydir  = pwd;
 % Find indices of slashes separating directories
 if ispc
@@ -28,88 +28,111 @@ if ispc
 elseif isunix
     idcs = strfind(mydir,'/');
 end
-% Remove the two sub folders to reach top-level directory
-% (psoct_vessel_graphing)
+% Truncate path to reach top-level directory (psoct_vessel_graphing)
 topdir = mydir(1:idcs(end));
 addpath(genpath(topdir));
 
+%% Automate segmentation of multiple volumes
+%{
+dpath = '/projectnb/npbssmic/ns/Ann_Mckee_samples_10T/';
+subid = {'AD_10382', 'AD_20832', 'AD_20969', 'AD_21354', 'AD_21424',...
+         'CTE_6489', 'CTE_6912', 'CTE_7019', 'CTE_8572', 'CTE_7126',...
+         'NC_21499', 'NC_6047', 'NC_6839', 'NC_6974', 'NC_7597',...
+         'NC_8095', 'NC_8653'};
+for ii = length(subid)
+    % Set voxel size from filename (either "_10ds" or "_4ds")
+
+    % Segment
+
+    % Mask
+
+    % Convert to graph
+
+    % Initialize graph structure information
+
+    % Downsample graph
+
+    % Prune loops
+
+    % Straighten segments
+end
+%}
 
 %% Import volume (.TIF or .BTF) & convert to MAT 
 
-%%% Local paths (windows PC)
-%{
-dpath = 'C:\Users\mack\Documents\BU\Boas_Lab\psoct_human_brain_resources\test_data\Hui_Frangi_dataset\200218depthnorm\';
-fname = 'volume_ori_inv_cropped';
-% filename extension
-ext = '.tif';
-filename = strcat(dpath, strcat(fname,ext));
-% Convert .tif to .MAT
-vol = TIFF2MAT(filename);
-%}
+% Check if running on local machine for debugging or on SCC for processing
+if ispc
+    %%% Local machine
+    dpath = 'C:\Users\mack\Documents\BU\Boas_Lab\psoct_human_brain_resources\test_data\Hui_Frangi_dataset\200218depthnorm\';
+    fname = 'volume_ori_inv_cropped';
+    % filename extension
+    ext = '.tif';
+    filename = strcat(dpath, strcat(fname,ext));
+    % Convert .tif to .MAT
+    vol = TIFF2MAT(filename);
+elseif isunix
+    %%% Computing cluster (SCC)
+    dpath = '/projectnb/npbssmic/ns/Ann_Mckee_samples_10T/AD_10382/dist_corrected/volume/';
+    fname = 'ref_4ds_norm';
+    % filename extension
+    ext = '.btf';
+    filename = strcat(dpath, strcat(fname,ext));
+    % Convert .tif to .MAT
+    vol = TIFF2MAT(filename);
+end
 
-%%% SCC paths
+%% Initialization parameters
 
-dpath = '/projectnb/npbssmic/ns/Ann_Mckee_samples_10T/AD_10382/dist_corrected/volume/';
-fname = 'ref_4ds_norm';
-% filename extension
-ext = '.btf';
-filename = strcat(dpath, strcat(fname,ext));
-% Convert .tif to .MAT
-vol = TIFF2MAT(filename);
-%}
-
-%% Set Voxel Size
 %%% Assign PS-OCT voxel dimension [x, y, z] according to downsample factor
 % Downasample factor = 4 --> Voxel = [12, 12, 15] micron
 % Downasample factor = 10 --> Voxel = [30, 30, 35] micron
-% TODO: Create function to extract downsample and voxel size from filename.
-%       The filename contains either "_10ds" or "_4ds".
+% 2P microscopy voxel will always be 5um x 5um
 
-% Temporary hard-coded voxel dimensions
-% PS-OCT voxel dimensions (microns)
+% PS-OCT voxel dimensions (microns) (hard coded for debugging)
 vox_dim = [30, 30, 35];
-
-%%% 2P microscopy voxel will always be 5um x 5um
-vox2p = [5, 5];
-
-%% Segment the volume
 % Std. Dev. for gaussian filter
 sigma = 1;
-% threshold to determine whether voxel belongs to a vessel. This is applied
-% to the probability matrix from the output of the frangi filter.
+% Threshold for Frangi filter probability matrix (voxel<thresh = not vessel)
 thresh = 0.2;
-% Segments with few than "min_conn" voxels will be removed
+% A segment with < "min_conn" voxels will be removed
 min_conn = 30;
-
-% Run segmentation function
-[I_seg] = ...
-    segment_main(dpath, fname, ext, sigma, thresh, min_conn);
-
-% Save segmentation before applying mask
-fname = strcat(fname,'_segment','_sigma', num2str(sigma));
-fout = strcat(dpath, fname, '.tif');
-segmat2tif(I_seg, fout);
-
-%% Apply mask to segmentation volume -- remove erroneous vessels
-% TODO: find optimal range for remove_mask_islands
 
 % Create 3D mask from original volume
 mask = logical(vol);
 % Array of radii for eroding the mask
-radii = 10:2:22;
+radii = 10:2:14;
 
-for ii = 1:length(radii)
-    %% Apply mask and save .MAT and .TIF
-    [I_seg_masked] = mask_segments(I_seg, mask, radii(ii), dpath, fname);
+% Boolean for converting segment to graph (0 = don't convert, 1 = convert)
+graph_boolean = 1;
 
-    %% Convert masked segmentation to graph
-    % Use masked segmentation to create graph
-    Graph = seg_to_graph(I_seg_masked, vox_dim);
+%% Segment the volume
+[I_seg, fname] = ...
+    segment_main(vol, sigma, thresh, min_conn, dpath, fname, ext);
+
+%% Mask segmented volume (remove erroneous vessels) & Convert to Graph
+% The function for creating the mask requires a radius. This for-loop will
+% iterate over an array of radii. For each radius, it will create a mask,
+% apply the mask to the segmentation volume, and save the output.
+% If the graph_boolean is true (1), then the masked segmentation will be
+% converted to a graph.
+
+for j = 1:length(radii)
+    %%% Apply mask and save .MAT and .TIF
+    [I_seg_masked] = mask_segments(I_seg, mask, radii(j), dpath, fname);
     
-    %% Create new filename for graph and add .MAT extension
-    tmp_fname = strcat(fname,'_masked_radius_', num2str(radii(ii)),'_graph.mat');
-    fout = strcat(dpath, tmp_fname);
-    save(fout,'Graph');
+    %%% Convert masked segmentation to graph
+    if graph_boolean
+        % Use masked segmentation to create graph
+        Graph = seg_to_graph(I_seg_masked, vox_dim);
+        
+        % initialize graph information
+%         Graph = initialize_graph(Graph);
+
+        % Create new filename for graph and add .MAT extension
+        tmp_fname = strcat(fname,'_masked_radius_', num2str(radii(j)),'_graph.mat');
+        fout = strcat(dpath, tmp_fname);
+        save(fout,'Graph');
+    end
 end
 
 %% Initialization of vesGraphValidate
@@ -163,35 +186,35 @@ save(fout, 'I_seg_masked', '-v7.3');
 end
 
 %% Segment volume
-function [I_seg] =...
-    segment_main(dpath, fname, ext, sigma, thresh, min_conn)
+function [I_seg, fname] =...
+    segment_main(vol, sigma, thresh, min_conn, dpath, fname)
 % Multiscale vessel segmentation
 %   INPUTS:
-%   sigma - vector of standard deviation values of gaussian filter to
+%       vol (matrix) - the original volume prior to segmentation
+%       sigma (array) - vector of std. dev. values of gaussian filter to
 %           calcualte hessian matrix at each voxel
-%   thres - threshold to determine which voxel belongs to a vessel. This is
-%           applied to the probability matrix from the output of the frangi
-%           filter.
-%   min_conn - vesSegment uses the function bwconncomp to determine the
+%       thres - threshold to determine which voxel belongs to a vessel.
+%           Applied to probability matrix from frangi filter output
+%       min_conn - vesSegment uses the function bwconncomp to determine the
 %               number of connected voxels for each segment. If the number
 %               of voxels is less than this threshold, then the segment
 %               will be removed.
+%       dpath (string) - absolute directory for saving processed data
+%       fname (string) - filename of segmentation
+%       ext (string) - filename extension (.TIF or .MAT)
 %   OUTPUTS:
 %       I_seg - segmentation of vessels (Frangi filter of original volume)
-%       I_seg_masked - masked segmentation (removed borders)
+%       fname (string) - upadted filename prior to applying mask
 
-%%% Load .TIF and convert to .MAT
-filename = strcat(dpath, strcat(fname,ext));
-vol = TIFF2MAT(filename);
-% convert volume to double matrix
+%% convert volume to double matrix
 I = double(vol);
 
 %%% Segment the original volume
 [~, I_seg] = vesSegment(I, sigma, thresh, min_conn);
 
-%%% Apply a mask to segmentation
-% Scalar for determining how much to erode mask
-% epsilon = 1;
-% I_seg_masked = mask_segments(I, I_seg, epsilon);
+%%% Save segmentation
+fname = strcat(fname,'_segment','_sigma', num2str(sigma));
+fout = strcat(dpath, fname, '.tif');
+segmat2tif(I_seg, fout);
 
 end

--- a/vasculature/psoct_vessel_segmentation_main.m
+++ b/vasculature/psoct_vessel_segmentation_main.m
@@ -15,6 +15,7 @@ To Do:
     - remove segments ()
 %}
 clear; clc; close all;
+tic
 
 %% Add top-level directory of code repository to path
 % This allows Matlab to find the functions in the project folders
@@ -70,8 +71,13 @@ end
 
 % PS-OCT voxel dimensions (microns) (hard coded for debugging)
 vox_dim = [30, 30, 35];
+
 % Std. Dev. for gaussian filter (one value or array)
+% The value of sigma corresponds to the smallest resolvable radius of the
+% vessels. If sigma==1, then the smallest resolvable vessel will be
+% 1*voxel. In our case, the smallest resolvable vessel has a radius = 12um
 sigma = 1;
+
 % Minimum fringi filter probability to classify voxel as vessel
 min_prob = 0.1:0.05:0.25;
 % A segment with < "min_conn" voxels will be removed
@@ -124,6 +130,7 @@ for ii = 1:length(subid)
         end
     end
 end
+toc
 
 %% Initialization of vesGraphValidate
 function [graph_init] = initialize_graph(Graph)

--- a/vasculature/psoct_vessel_segmentation_main.m
+++ b/vasculature/psoct_vessel_segmentation_main.m
@@ -37,7 +37,7 @@ addpath(genpath(topdir));
 %% Import volume (.TIF or .BTF) & convert to MAT 
 
 %%% Local paths (windows PC)
-
+%{
 dpath = 'C:\Users\mack\Documents\BU\Boas_Lab\psoct_human_brain_resources\test_data\Hui_Frangi_dataset\200218depthnorm\';
 fname = 'volume_ori_inv_cropped';
 % filename extension
@@ -47,8 +47,8 @@ filename = strcat(dpath, strcat(fname,ext));
 vol = TIFF2MAT(filename);
 %}
 
-%%% SCC paths (windows PC)
-%{
+%%% SCC paths
+
 dpath = '/projectnb/npbssmic/ns/Ann_Mckee_samples_10T/AD_10382/dist_corrected/volume/';
 fname = 'ref_4ds_norm';
 % filename extension

--- a/vasculature/psoct_vessel_segmentation_main.m
+++ b/vasculature/psoct_vessel_segmentation_main.m
@@ -64,21 +64,28 @@ end
 if ispc
     %%% Local machine
     dpath = 'C:\Users\mack\Documents\BU\Boas_Lab\psoct_human_brain_resources\test_data\Hui_Frangi_dataset\200218depthnorm\';
+    % Subject IDs
+    subid = {'sub_00'};
+    subdir = '\dist_corrected\volume\';
+    % Filename to parse (this is test data)
     fname = 'volume_ori_inv_cropped';
     % filename extension
     ext = '.tif';
-    filename = strcat(dpath, strcat(fname,ext));
-    % Convert .tif to .MAT
-    vol = TIFF2MAT(filename);
 elseif isunix
     %%% Computing cluster (SCC)
-    dpath = '/projectnb/npbssmic/ns/Ann_Mckee_samples_10T/AD_10382/dist_corrected/volume/';
+    % Path to top-level directory
+    dpath = '/projectnb/npbssmic/ns/Ann_Mckee_samples_10T/';
+    % Subject IDs
+%     subid = {'AD_10382', 'AD_20832', 'AD_20969', 'AD_21354', 'AD_21424',...
+%              'CTE_6489', 'CTE_6912', 'CTE_7019', 'CTE_8572', 'CTE_7126',...
+%              'NC_21499', 'NC_6047', 'NC_6839', 'NC_6974', 'NC_7597',...
+%              'NC_8095', 'NC_8653'};
+    subid = {'AD_10382', 'AD_20832'};
+    subdir = '/dist_corrected/volume/';
+    % Filename to parse (this will be the same for each subject)
     fname = 'ref_4ds_norm';
     % filename extension
-    ext = '.btf';
-    filename = strcat(dpath, strcat(fname,ext));
-    % Convert .tif to .MAT
-    vol = TIFF2MAT(filename);
+    ext = '.btf';    
 end
 
 %% Initialization parameters
@@ -90,48 +97,57 @@ end
 
 % PS-OCT voxel dimensions (microns) (hard coded for debugging)
 vox_dim = [30, 30, 35];
-% Std. Dev. for gaussian filter
+% Std. Dev. for gaussian filter (one value or array)
 sigma = 1;
 % Threshold for Frangi filter probability matrix (voxel<thresh = not vessel)
 thresh = 0.2;
 % A segment with < "min_conn" voxels will be removed
 min_conn = 30;
 
-% Create 3D mask from original volume
-mask = logical(vol);
 % Array of radii for eroding the mask
 radii = 10:2:14;
 
 % Boolean for converting segment to graph (0 = don't convert, 1 = convert)
 graph_boolean = 1;
 
-%% Segment the volume
-[I_seg, fname] = ...
-    segment_main(vol, sigma, thresh, min_conn, dpath, fname, ext);
+for ii = 1:length(subid)
+    %% Segment the volume
+    % Define entire filepath 
+    fullpath = fullfile(dpath, subid{ii}, subdir);
+    filename = strcat(fullpath, strcat(fname, ext));
+    % Convert .tif to .MAT
+    vol = TIFF2MAT(filename);
 
-%% Mask segmented volume (remove erroneous vessels) & Convert to Graph
-% The function for creating the mask requires a radius. This for-loop will
-% iterate over an array of radii. For each radius, it will create a mask,
-% apply the mask to the segmentation volume, and save the output.
-% If the graph_boolean is true (1), then the masked segmentation will be
-% converted to a graph.
-
-for j = 1:length(radii)
-    %%% Apply mask and save .MAT and .TIF
-    [I_seg_masked] = mask_segments(I_seg, mask, radii(j), dpath, fname);
+    [I_seg, fname_seg] = ...
+        segment_main(vol, sigma, thresh, min_conn, fullpath, fname);
     
-    %%% Convert masked segmentation to graph
-    if graph_boolean
-        % Use masked segmentation to create graph
-        Graph = seg_to_graph(I_seg_masked, vox_dim);
-        
-        % initialize graph information
-%         Graph = initialize_graph(Graph);
+    %% Mask segmented volume (remove erroneous vessels) & Convert to Graph
+    % The function for creating the mask requires a radius. This for-loop will
+    % iterate over an array of radii. For each radius, it will create a mask,
+    % apply the mask to the segmentation volume, and save the output.
+    % If the graph_boolean is true (1), then the masked segmentation will be
+    % converted to a graph.
 
-        % Create new filename for graph and add .MAT extension
-        tmp_fname = strcat(fname,'_masked_radius_', num2str(radii(j)),'_graph.mat');
-        fout = strcat(dpath, tmp_fname);
-        save(fout,'Graph');
+    % Create 3D mask from original volume
+    mask = logical(vol);
+    
+    for j = 1:length(radii)
+        %%% Apply mask and save .MAT and .TIF
+        [I_seg_masked] = mask_segments(I_seg, mask, radii(j), fullpath, fname_seg);
+        
+        %%% Convert masked segmentation to graph
+        if graph_boolean
+            % Use masked segmentation to create graph
+            Graph = seg_to_graph(I_seg_masked, vox_dim);
+            
+            % initialize graph information
+    %         Graph = initialize_graph(Graph);
+    
+            % Create new filename for graph and add .MAT extension
+            fname_graph = strcat(fname_seg,'_masked_radius_', num2str(radii(j)),'_graph.mat');
+            fout = strcat(dpath, fname_graph);
+            save(fout,'Graph');
+        end
     end
 end
 
@@ -144,16 +160,17 @@ function [graph_init] = initialize_graph(Graph)
 % Open GUI with both image and data (graph)
 % Run prune_loops and prune_segment
 % Run straighten
+graph_init = Graph;
 end
 
 %% Apply Mask
-function [I_seg_masked] = mask_segments(I_seg, mask, radius, dpath, fname)
+function [I_seg_masked] = mask_segments(I_seg, mask, radius, fullpath, fname)
 % Remove the edges labeled as vessels.
 %   INPUTS:
 %       I_seg (matrix) - output of segmentation function
 %       mask (matrix) - unsegmented volume converted to logicals
 %       radius (double array) - radius of disk for eroding the mask
-%       dpath (string) - absolute directory for saving processed data
+%       fullpath (string) - absolute directory for saving processed data
 %       fname (string) - filename prior to applying mask
 %   OUTPUTS:
 %       I_seg_masked (matrix) - I_seg with boundaries eroded to remove
@@ -177,17 +194,17 @@ I_seg_masked = apply_mask(I_seg, mask);
 %%% Save segmented/masked volume as .MAT and .TIF
 % Convert masked image back to tif
 tmp_fname = strcat(fname,'_masked_radius_', num2str(radius));
-fout = strcat(dpath, tmp_fname, '.tif');
+fout = strcat(fullpath, tmp_fname, '.tif');
 segmat2tif(I_seg_masked, fout);
 % Save vessel segment stack as .MAT for the next step (graph recon)
-fout = strcat(dpath, tmp_fname, '.mat');
+fout = strcat(fullpath, tmp_fname, '.mat');
 save(fout, 'I_seg_masked', '-v7.3');
 
 end
 
 %% Segment volume
 function [I_seg, fname] =...
-    segment_main(vol, sigma, thresh, min_conn, dpath, fname)
+    segment_main(vol, sigma, thresh, min_conn, fullpath, fname)
 % Multiscale vessel segmentation
 %   INPUTS:
 %       vol (matrix) - the original volume prior to segmentation
@@ -199,7 +216,7 @@ function [I_seg, fname] =...
 %               number of connected voxels for each segment. If the number
 %               of voxels is less than this threshold, then the segment
 %               will be removed.
-%       dpath (string) - absolute directory for saving processed data
+%       fullpath (string) - absolute directory for saving processed data
 %       fname (string) - filename of segmentation
 %       ext (string) - filename extension (.TIF or .MAT)
 %   OUTPUTS:
@@ -214,7 +231,7 @@ I = double(vol);
 
 %%% Save segmentation
 fname = strcat(fname,'_segment','_sigma', num2str(sigma));
-fout = strcat(dpath, fname, '.tif');
+fout = strcat(fullpath, fname, '.tif');
 segmat2tif(I_seg, fout);
 
 end

--- a/vasculature/seg_to_graph.m
+++ b/vasculature/seg_to_graph.m
@@ -28,17 +28,8 @@ elseif  strcmp(ext,'.tiff') || strcmp(ext,'.tif')
         end
     end
 end
-
 % Convert all nonzero values into a logical 1.
 vessel_mask = logical(angio);
-
-% remove islands from raw segments
-CC = bwconncomp(vessel_mask);
-for uuu = 1:length(CC.PixelIdxList)
-    if length(CC.PixelIdxList{uuu}) < 100    % 30 for default
-        vessel_mask(CC.PixelIdxList{uuu}) = 0;
-    end
-end
 
 %% Create graph from binary vessel mask
 % Reduce 3-D binary volume to a curve skeleton
@@ -59,16 +50,17 @@ angio_size = size(vessel_mask);
 nodes_ind_count = length(vessel_graph.node.cc_ind)+length(vessel_graph.link.pos_ind);
 nodes_ind = zeros(1,nodes_ind_count);
 
-% find length of edges to allocate size
+% find number of edges to preallocate matrix
 edges_ind_count = 0;
-% link_cc_ind = zeros(size(vessel_graph.link.cc_ind));
 for u = 1:length(vessel_graph.node.connected_link_label)
-    edges_ind_count = edges_ind_count+length(vessel_graph.node.connected_link_label{u});
+    edges_ind_count =...
+        edges_ind_count + length(vessel_graph.node.connected_link_label{u});
 end
 for  u = 1:length(vessel_graph.link.cc_ind)
-    edges_ind_count = edges_ind_count+length(vessel_graph.link.cc_ind{u})-1;
+    edges_ind_count =...
+        edges_ind_count + length(vessel_graph.link.cc_ind{u})-1;
 end
-
+% Preallocate matrix for storing edge indice
 edges_ind = zeros(edges_ind_count,2);
 %% Assign nodes and edges. 
 % TODO: preallocate variable "tttt"

--- a/vasculature/seg_to_graph.m
+++ b/vasculature/seg_to_graph.m
@@ -1,34 +1,13 @@
-function [graph] = seg_to_graph(segment, vox_dim)
+function [graph] = seg_to_graph(angio, vox_dim)
 %seg_to_graph Convert the vessel segments to a graph (nodes + vertices)
-% This function is the second step in the vessel segmentation pipeline.
-% This function can take either a .MAT or .TIF
-%
 %%% INPUTS:
-%       segment (str): '[absolute path]/name' of segmentation data (.TIF or .MAT)
+%       angio (matrix): segmented volume
 %       vox_dim (array): voxel dimensions (x, y, z) (micron)
 %%% OUTPUTS:
-%       graph (struct): nodes and edges for graph of segmentation
+%       Graph (struct): nodes and edges for graph of segmentation
 
 
 %% Create the local vessel_mask variable
-[~,~,ext] = fileparts(segment);
-if strcmp(ext,'.mat')
-    temp = load(segment);
-    fn = fieldnames(temp);
-    angio = temp.(fn{1});
-elseif  strcmp(ext,'.tiff') || strcmp(ext,'.tif')
-    info = imfinfo(segment);
-    for u = 1:length(info)
-        if u == 1
-            temp = imread(segment,1);
-            angio = zeros([size(temp) length(info)]);
-            angio(:,:,u) = temp;
-        else
-            angio(:,:,u) = imread(segment,u);
-        end
-    end
-end
-% Convert all nonzero values into a logical 1.
 vessel_mask = logical(angio);
 
 %% Create graph from binary vessel mask
@@ -154,14 +133,5 @@ graph.edges(same_edge_idx,:) = [];
 temp = graph.nodes(:,2);
 graph.nodes(:,2) = graph.nodes(:,1);
 graph.nodes(:,1) = temp;
-
-%% Run the initialization steps in GUI:
-% "Verification -> Get Segment Info -> Update"
-% "Verification -> Update Branch Info"
-
-%% Run regraph (straighten) & prune loops
-%
-
-%% Remove floating nodes (see logic in 
 
 end

--- a/vasculature/vesGraphValidate/prune_loops.m
+++ b/vasculature/vesGraphValidate/prune_loops.m
@@ -116,7 +116,7 @@ end
 Data.Graph.segInfo.loops = loops;
 disp([num2str(length(loops)) ' loops are detected in the graph.']);
 
-%% 
+%%  What is purpose of this?
 segmentstodelete = [];
 for v = 1:length(Data.Graph.segInfo.loops)   
     nodeno = Data.Graph.segInfo.loops(v);
@@ -127,7 +127,7 @@ end
 nodes = Data.Graph.nodes;
 edges = Data.Graph.edges;
 
-%% 
+%%  What is purpose of this?
 lstRemove=[];
 for i=1:length(segmentstodelete)
     idx =  find(Data.Graph.segInfo.nodeSegN == segmentstodelete(i));

--- a/vasculature/vesGraphValidate/regraphNodes_new.m
+++ b/vasculature/vesGraphValidate/regraphNodes_new.m
@@ -11,6 +11,7 @@ if ~exist('nodeDiam')
     nodeDiam = zeros(nNodes,1);
 end
 
+% Change this from ds_rate to voxel size?
 hxy = ds_rate;
 hz = ds_rate;
 

--- a/vasculature/vesSegment/apply_mask.m
+++ b/vasculature/vesSegment/apply_mask.m
@@ -25,4 +25,7 @@ masked = uint16(orig_re) .* mask_re;
 % Reshape the masked image back to original shape
 masked = reshape(masked, [r, c, s]);
 
+% Convert masked from logical back to grayscale [0, 255]
+masked(masked==1) = 255;
+
 end

--- a/vasculature/vesSegment/remove_mask_islands.m
+++ b/vasculature/vesSegment/remove_mask_islands.m
@@ -21,12 +21,6 @@ mask_re = logical(mask_re);
 % Find/delete islands in the mask
 mask_rm = bwareafilt(mask_re, range);
 
-% Debugging figure
-figure;
-subplot(2,1,1); imshow(mask_re(:,1:(2*c))); title('Original Mask')
-subplot(2,1,2); imshow(mask_rm(:,1:(2*c))); title('Cleaned Mask')
-
-
 % Convert back to 3D matrix
 mask_rm = reshape(mask_rm, [r, c, s]);
 

--- a/vasculature/vesSegment/vesSegment.m
+++ b/vasculature/vesSegment/vesSegment.m
@@ -8,7 +8,7 @@ function [w, I_seg] = vesSegment(I, sigma, thres, min_conn)
 %           calcualte hessian matrix at each voxel
 %   thres - threshold to determine which voxel belongs to a vessel. This is
 %           applied to the probability matrix from the output of the frangi
-%           filter.
+%           filter. The threshold belongs to [0, 1].
 %   vox_dim - voxel dimensions [x,y,z] (microns)
 %
 % OUTPUTS:

--- a/vasculature/vessel_geometry_main.m
+++ b/vasculature/vessel_geometry_main.m
@@ -43,3 +43,50 @@ figure;histogram(dia_vessel,'BinWidth',10);
 length_vessel=sum(:,1).*sum(:,6);
 length_vessel(length_vessel(:)==0)=[];    % get rid of fake vessels
 figure;histogram(length_vessel.*10,0:25:1000);
+
+%% Calculate Diameter
+%{
+% Load Graph struct
+fname = 'volume_nor_inverted_masked_sigma1_frangi_seg_regraphed';
+dpath =...
+    'C:\Users\mack\Documents\BU\Boas_Lab\psoct_human_brain_resources\test_data\Hui_Frangi_dataset\200726PSOCT\';
+fpath = strcat(dpath, strcat(fname,'.mat'));
+Data = load(fpath,'Graph');
+
+% Call function to calculate diameter at each node
+Diam = GetDiam_graph(...
+    vol,...
+    Data.Graph.nodes,...
+    Data.Graph.edges,...
+    Ithresh,...
+    vox_dim);
+%}
+%% Calculate Tortuosity
+%{
+tortuosity = vessel_tortuosity_index(Data.Graph, Ithresh);
+%}
+%% Histograms for geometries
+%{
+% Histo for diameter
+figure; histogram(Diam);
+title('Vessel Diameter')
+xlabel('Diameter (microns)')
+ylabel('Count')
+set(gca, 'FontSize', 20)
+
+% Histo for diameter
+figure; histogram(tortuosity);
+title('Vessel Tortuosity')
+xlabel('Tortuosity (unitless)')
+ylabel('Count'); ylim([0,200])
+set(gca, 'FontSize', 20)
+%}
+
+%% (OLD CODE) Median diameter
+%{
+dia_vessel=zeros(1,length(Data.Graph.segInfo.segLen));
+for i=1:length(dia_vessel)
+    dia_vessel(i)=median(Diam(find(Data.Graph.segInfo.nodeSegN(:)==i)));
+end
+figure; histogram(dia_vessel,'BinWidth',10);
+%}


### PR DESCRIPTION
This branch includes a main script for creating a mask, eroding the boundaries, and applying it to the segmentation output. This removes most of the erroneously labeled vessels along the perimeter of each slice. There are still some false positives that require fine tuning to remove completely.
